### PR TITLE
chore: remove ignore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ Config is specified via the plugin's JSON config file.
   "publish_all_accounts": false,
   "publish_accounts_without_signature": false,
   "wrap_messages": false,
-  "program_ignores": [
-    "Sysvar1111111111111111111111111111111111111",
-    "Vote111111111111111111111111111111111111111"
-  ]
   "program_allowlist_url": "https://example.com/program_allowlist.txt",
   "program_allowlist_expiry_sec": 5,
 }
@@ -73,7 +69,6 @@ Config is specified via the plugin's JSON config file.
 - `publish_all_accounts`: Publish all accounts on startup. Omit to disable.
 - `publish_accounts_without_signature`: Publish account updates that have no transaction (signature) associated. Omit to disable.
 - `wrap_messages`: Wrap all messages in a unified wrapper object. Omit to disable (see Message Wrapping below).
-- `program_ignores`: Account addresses to ignore (see Filtering below).
 - `program_allowlist_url`: HTTP URL to fetch the program allowlist from. The file must be json, and with the following schema:
   ```json
   {
@@ -95,9 +90,11 @@ The message types are keyed as follows:
 
 ### Filtering
 
-If `program_ignores` are specified, then these addresses will be filtered out of the account updates
+~~If `program_ignores` are specified, then these addresses will be filtered out of the account updates
 and transaction notifications.  More specifically, account update messages for these accounts will not be emitted,
-and transaction notifications for any transaction involving these accounts will not be emitted.
+and transaction notifications for any transaction involving these accounts will not be
+emitted.~~
+`program_ignores` were removed and only `program_allowlist` is supported now.
 
 ### Message Wrapping
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,9 +43,6 @@ pub struct Config {
     /// Kafka topic to send transaction to.
     #[serde(default)]
     pub transaction_topic: String,
-    /// List of programs to ignore.
-    #[serde(default)]
-    pub program_ignores: Vec<String>,
     /// Publish all accounts on startup.
     #[serde(default)]
     pub publish_all_accounts: bool,
@@ -86,7 +83,6 @@ impl Default for Config {
             update_account_topic: "".to_owned(),
             slot_status_topic: "".to_owned(),
             transaction_topic: "".to_owned(),
-            program_ignores: Vec::new(),
             publish_all_accounts: false,
             publish_accounts_without_signature: false,
             program_allowlist: Vec::new(),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -32,7 +32,6 @@ impl Filter {
     }
 
     pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
-        // If allowlist is not empty, only allowlist is used.
         if self.program_allowlist.len() > 0 {
             self.program_allowlist.wants_program(account_key)
         } else {


### PR DESCRIPTION
## Summary

Removing support for `program_ignores` since in our case they won't be needed.

## Details

This quick fix was added due to our infrastructure coming to it's knees due to the following:

1.fetching allow list failed thus it stayed empty
2. when asked to publish an account update the check just made sure that the ignore list
doesn't have it
3. we published updates for accounts of _all_ programs

After this fix the behavior is as follows:

1. fetching allow list may fail
2. when asked to publish an account update the check just makes sure that the allow list has it
  if the allowlist is empty then we don't publish the account update
3. as a result in a case of failure we don't publish any account updates instead of overloading
our infrastructure
