### PR TITLE
feat: adding environment awareness

### DIFF
--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::{Config, EnvConfig};
+use crate::EnvConfig;
 
 use solana_geyser_plugin_interface::geyser_plugin_interface::{
     GeyserPluginError as PluginError, Result as PluginResult,

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -276,12 +276,12 @@ mod tests {
     use super::*;
     #[test]
     fn test_allowlist_from_vec() {
-        let config = Config {
+        let config = EnvConfig {
             program_allowlist: vec![
                 "Sysvar1111111111111111111111111111111111111".to_owned(),
                 "Vote111111111111111111111111111111111111111".to_owned(),
             ],
-            ..Config::default()
+            ..EnvConfig::default()
         };
 
         let allowlist = Allowlist::new_from_vec(config.program_allowlist).unwrap();

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::Config;
+use crate::{Config, EnvConfig};
 
 use solana_geyser_plugin_interface::geyser_plugin_interface::{
     GeyserPluginError as PluginError, Result as PluginResult,
@@ -41,7 +41,7 @@ impl Allowlist {
         let list = self.list.lock().unwrap();
         list.len()
     }
-    pub fn new_from_config(config: &Config) -> PluginResult<Self> {
+    pub fn new_from_config(config: &EnvConfig) -> PluginResult<Self> {
         if !config.program_allowlist_url.is_empty() {
             let mut out = Self::new_from_http(
                 &config.program_allowlist_url.clone(),
@@ -314,11 +314,11 @@ mod tests {
             .with_body("{\"result\":[\"Sysvar1111111111111111111111111111111111111\",\"Vote111111111111111111111111111111111111111\"]}")
             .create();
 
-        let config = Config {
+        let config = EnvConfig {
             program_allowlist_url: [mockito::server_url(), "/allowlist.txt".to_owned()].join(""),
             program_allowlist_expiry_sec: 3,
             program_allowlist: vec!["WormT3McKhFJ2RkiGpdw9GKvNCrB2aB54gb2uV9MfQC".to_owned()],
-            ..Config::default()
+            ..EnvConfig::default()
         };
 
         let mut allowlist = Allowlist::new_from_config(&config).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,32 +26,33 @@ use {
 /// Plugin config.
 #[derive(Deserialize)]
 pub struct Config {
-    /// Graceful shutdown timeout.
+    /// Time the plugin is given to flush out all messages to Kafka
+    /// and gracefully shutdown upon exit request.
     #[serde(default)]
     pub shutdown_timeout_ms: u64,
-    /// Kafka topic to send account updates to.
+    /// Kafka topic to send account updates to. Omit to disable.
     #[serde(default)]
     pub update_account_topic: String,
-    /// Kafka topic to send slot status updates to.
+    /// Kafka topic to send slot status updates to. Omit to disable.
     #[serde(default)]
     pub slot_status_topic: String,
-    /// Kafka topic to send transaction to.
+    /// Kafka topic to send transaction updates to. Omit to disable.
     #[serde(default)]
     pub transaction_topic: String,
-    /// Publish all accounts on startup.
+    /// Publish all accounts on startup. Omit to disable.
     #[serde(default)]
     pub publish_all_accounts: bool,
     /// Publishes account updates even if the txn_signature is not present.
     /// This will include account updates that occur without a corresponding
-    /// transaction, i.e. caused by validator book-keeping.
+    /// transaction, i.e. caused by validator book-keeping. Omit to disable.
     #[serde(default)]
     pub publish_accounts_without_signature: bool,
-    /// Wrap all event message in a single message type.
+    /// Wrap all messages in a unified wrapper object. Omit to disable.
     #[serde(default)]
     pub wrap_messages: bool,
 
     #[serde(default)]
-    /// Kafka cluster and allow list configs for different environments
+    /// Kafka cluster and allow list configs for different environments. See [EnvConfig].
     pub environments: Vec<EnvConfig>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,7 +59,13 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             shutdown_timeout_ms: 30_000,
-            ..Default::default()
+            update_account_topic: Default::default(),
+            slot_status_topic: Default::default(),
+            transaction_topic: Default::default(),
+            publish_all_accounts: Default::default(),
+            publish_accounts_without_signature: Default::default(),
+            wrap_messages: Default::default(),
+            environments: Default::default(),
         }
     }
 }
@@ -70,7 +76,7 @@ impl Config {
         let file = File::open(config_path)?;
         let mut this: Self = serde_json::from_reader(file)
             .map_err(|e| GeyserPluginError::ConfigFileReadError { msg: e.to_string() })?;
-        for env_config in this.environments {
+        for env_config in this.environments.iter_mut() {
             env_config.fill_defaults();
         }
         Ok(this)

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -41,7 +41,10 @@ impl Default for EnvConfig {
     fn default() -> Self {
         Self {
             program_allowlist_expiry_sec: 60,
-            ..Default::default()
+            kafka: Default::default(),
+            program_allowlist: Default::default(),
+            program_allowlist_url: Default::default(),
+            program_allowlist_auth: Default::default(),
         }
     }
 }

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -14,18 +14,24 @@ pub struct EnvConfig {
     #[serde(default)]
     pub name: String,
 
-    /// Kafka config.
+    /// Kafka [`librdkafka` config options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
     pub kafka: HashMap<String, String>,
 
     /// Allowlist of programs to publish.
-    /// If empty, all accounts are published.
+    /// If empty, no accounts are published.
     /// If not empty, only accounts owned by programs in this list are published.
     #[serde(default)]
     pub program_allowlist: Vec<String>,
 
-    /// Allowlist from http url.
-    /// If empty, all accounts are published.
-    /// If not empty, only accounts owned by programs in this list are published.
+    /// URL to fetch allowlist updates from
+    /// The file must be json, and with the following schema:
+    /// ```
+    ///{
+    ///   "result": [
+    ///       "11111111111111111111111111111111",
+    ///       "22222222222222222222222222222222"
+    ///   ]
+    /// }
     #[serde(default)]
     pub program_allowlist_url: String,
 

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -25,13 +25,14 @@ pub struct EnvConfig {
 
     /// URL to fetch allowlist updates from
     /// The file must be json, and with the following schema:
-    /// ```
-    ///{
+    /// ```json
+    /// {
     ///   "result": [
     ///       "11111111111111111111111111111111",
     ///       "22222222222222222222222222222222"
     ///   ]
     /// }
+    /// ```
     #[serde(default)]
     pub program_allowlist_url: String,
 

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -5,6 +5,8 @@ use rdkafka::{
 };
 use serde::Deserialize;
 
+use crate::Producer;
+
 /// Environment specific config.
 #[derive(Deserialize)]
 pub struct EnvConfig {
@@ -38,11 +40,8 @@ pub struct EnvConfig {
 impl Default for EnvConfig {
     fn default() -> Self {
         Self {
-            kafka: HashMap::new(),
-            program_allowlist: Vec::new(),
-            program_allowlist_url: "".to_owned(),
-            program_allowlist_auth: "".to_owned(),
             program_allowlist_expiry_sec: 60,
+            ..Default::default()
         }
     }
 }

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -10,6 +10,10 @@ use crate::Producer;
 /// Environment specific config.
 #[derive(Deserialize)]
 pub struct EnvConfig {
+    /// Name of the environment
+    #[serde(default)]
+    pub name: String,
+
     /// Kafka config.
     pub kafka: HashMap<String, String>,
 
@@ -41,6 +45,7 @@ impl Default for EnvConfig {
     fn default() -> Self {
         Self {
             program_allowlist_expiry_sec: 60,
+            name: Default::default(),
             kafka: Default::default(),
             program_allowlist: Default::default(),
             program_allowlist_url: Default::default(),

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// Environment specific config.
+#[derive(Deserialize)]
+pub struct EnvConfig {
+    /// Kafka config.
+    pub kafka: HashMap<String, String>,
+
+    /// Allowlist of programs to publish.
+    /// If empty, all accounts are published.
+    /// If not empty, only accounts owned by programs in this list are published.
+    #[serde(default)]
+    pub program_allowlist: Vec<String>,
+
+    /// Allowlist from http url.
+    /// If empty, all accounts are published.
+    /// If not empty, only accounts owned by programs in this list are published.
+    #[serde(default)]
+    pub program_allowlist_url: String,
+
+    /// Allowlist Authorization header value.
+    /// If provided the request to the program_allowlist_url will add an
+    /// 'Authorization: <value>' header.
+    /// A sample auth header value would be 'Bearer my_long_secret_token'.
+    #[serde(default)]
+    pub program_allowlist_auth: String,
+
+    /// Update iterval for allowlist from http url.
+    #[serde(default)]
+    pub program_allowlist_expiry_sec: u64,
+}
+
+impl Default for EnvConfig {
+    fn default() -> Self {
+        Self {
+            kafka: HashMap::new(),
+            program_allowlist: Vec::new(),
+            program_allowlist_url: "".to_owned(),
+            program_allowlist_auth: "".to_owned(),
+            program_allowlist_expiry_sec: 60,
+        }
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -21,7 +21,7 @@ pub struct Filter {
 }
 
 impl Filter {
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &EnvConfig) -> Self {
         Self {
             program_allowlist: Allowlist::new_from_config(config).unwrap(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use solana_geyser_plugin_interface::geyser_plugin_interface::GeyserPlugin;
 
 mod allowlist;
 mod config;
+mod env_config;
 mod event;
 mod filter;
 mod plugin;
@@ -27,6 +28,7 @@ mod publisher;
 
 pub use {
     config::{Config, Producer},
+    env_config::EnvConfig,
     event::*,
     filter::Filter,
     plugin::KafkaPlugin,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -26,10 +26,14 @@ use {
     std::fmt::{Debug, Formatter},
 };
 
+pub struct FilteredPublisher {
+    publisher: Publisher,
+    filter: Filter,
+}
+
 #[derive(Default)]
 pub struct KafkaPlugin {
-    publisher: Option<Publisher>,
-    filter: Option<Filter>,
+    publishers: Option<Vec<FilteredPublisher>>,
     publish_all_accounts: bool,
     publish_accounts_without_signature: bool,
 }
@@ -46,7 +50,7 @@ impl GeyserPlugin for KafkaPlugin {
     }
 
     fn on_load(&mut self, config_file: &str) -> PluginResult<()> {
-        if self.publisher.is_some() {
+        if self.publishers.is_some() {
             let err = simple_error!("plugin already loaded");
             return Err(PluginError::Custom(Box::new(err)));
         }
@@ -64,22 +68,25 @@ impl GeyserPlugin for KafkaPlugin {
         let (version_n, version_s) = get_rdkafka_version();
         info!("rd_kafka_version: {:#08x}, {}", version_n, version_s);
 
-        let producer = config
-            .producer()
-            .map_err(|e| PluginError::Custom(Box::new(e)))?;
-        info!("Created rdkafka::FutureProducer");
+        let publishers = Vec::new();
+        for env_config in config.environments {
+            let producer = env_config
+                .producer()
+                .map_err(|e| PluginError::Custom(Box::new(e)))?;
+            info!("Created rdkafka::FutureProducer");
 
-        let publisher = Publisher::new(producer, &config);
-        self.publisher = Some(publisher);
-        self.filter = Some(Filter::new(&config));
-        info!("Spawned producer");
+            let publisher = Publisher::new(producer, &config);
+            let filter = Filter::new(&env_config);
+            publishers.push(FilteredPublisher { publisher, filter })
+        }
+        self.publishers = Some(publishers);
+        info!("Spawned producers");
 
         Ok(())
     }
 
     fn on_unload(&mut self) {
-        self.publisher = None;
-        self.filter = None;
+        self.publishers = None;
     }
 
     fn update_account(
@@ -96,14 +103,14 @@ impl GeyserPlugin for KafkaPlugin {
         if !self.publish_accounts_without_signature && info.txn_signature.is_none() {
             return Ok(());
         }
-        if !self.unwrap_filter().wants_account_key(info.owner) {
+        if !self.unwrap_filters().wants_account_key(info.owner) {
             Self::log_ignore_account_update(info);
             return Ok(());
         }
 
         // Trigger an update of the remote allowlist
         // but don't wait for it to complete.
-        self.unwrap_filter()
+        self.unwrap_filters()
             .get_allowlist()
             .update_from_http_if_needed_async();
 
@@ -119,10 +126,21 @@ impl GeyserPlugin for KafkaPlugin {
             txn_signature: info.txn_signature.map(|sig| sig.as_ref().to_owned()),
         };
 
-        let publisher = self.unwrap_publisher();
-        publisher
-            .update_account(event)
-            .map_err(|e| PluginError::AccountsUpdateError { msg: e.to_string() })
+        let publishers = self.unwrap_publishers();
+        let mut errors = Vec::new();
+        for publisher in publishers {
+            if let Err(err) = publisher.update_account(event) {
+                errors.push(err.to_string());
+            }
+        }
+        if !errors.is_empty() {
+            // TODO(thlorenz): think about naming environments and including that info here
+            Err(PluginError::AccountsUpdateError {
+                msg: errors.join(" | "),
+            })
+        } else {
+            Ok(())
+        }
     }
 
     fn update_slot_status(
@@ -131,20 +149,32 @@ impl GeyserPlugin for KafkaPlugin {
         parent: Option<u64>,
         status: PluginSlotStatus,
     ) -> PluginResult<()> {
-        let publisher = self.unwrap_publisher();
-        if !publisher.wants_slot_status() {
-            return Ok(());
+        let publishers = self.unwrap_publishers();
+
+        let mut errors = Vec::new();
+        for publisher in publishers {
+            if !publisher.wants_slot_status() {
+                continue;
+            }
+
+            let event = SlotStatusEvent {
+                slot,
+                parent: parent.unwrap_or(0),
+                status: SlotStatus::from(status).into(),
+            };
+
+            if let Err(err) = publisher.update_slot_status(event) {
+                errors.push(err.to_string());
+            }
         }
 
-        let event = SlotStatusEvent {
-            slot,
-            parent: parent.unwrap_or(0),
-            status: SlotStatus::from(status).into(),
-        };
-
-        publisher
-            .update_slot_status(event)
-            .map_err(|e| PluginError::AccountsUpdateError { msg: e.to_string() })
+        if !errors.is_empty() {
+            Err(PluginError::SlotStatusUpdateError {
+                msg: errors.join(" | "),
+            })
+        } else {
+            Ok(())
+        }
     }
 
     fn notify_transaction(
@@ -152,40 +182,54 @@ impl GeyserPlugin for KafkaPlugin {
         transaction: ReplicaTransactionInfoVersions,
         slot: u64,
     ) -> PluginResult<()> {
-        let publisher = self.unwrap_publisher();
-        if !publisher.wants_transaction() {
-            return Ok(());
+        let publishers = self.unwrap_publishers();
+        let mut errors = Vec::new();
+        for publisher in publishers {
+            if !publisher.wants_transaction() {
+                continue;
+            }
+
+            let info = Self::unwrap_transaction(transaction);
+            let maybe_ignored = info
+                .transaction
+                .message()
+                .account_keys()
+                .iter()
+                .find(|key| !self.unwrap_filters().wants_account_key(&key.to_bytes()));
+            if maybe_ignored.is_some() {
+                debug!(
+                    "Ignoring transaction {:?} due to account key: {:?}",
+                    info.signature,
+                    &maybe_ignored.unwrap()
+                );
+                return Ok(());
+            }
+
+            let event = Self::build_transaction_event(slot, info);
+
+            if let Err(err) = publisher.update_transaction(event) {
+                errors.push(err.to_string());
+            }
         }
-
-        let info = Self::unwrap_transaction(transaction);
-        let maybe_ignored = info
-            .transaction
-            .message()
-            .account_keys()
-            .iter()
-            .find(|key| !self.unwrap_filter().wants_account_key(&key.to_bytes()));
-        if maybe_ignored.is_some() {
-            debug!(
-                "Ignoring transaction {:?} due to account key: {:?}",
-                info.signature,
-                &maybe_ignored.unwrap()
-            );
-            return Ok(());
+        if !errors.is_empty() {
+            Err(PluginError::TransactionUpdateError {
+                msg: errors.join(" | "),
+            })
+        } else {
+            Ok(())
         }
-
-        let event = Self::build_transaction_event(slot, info);
-
-        publisher
-            .update_transaction(event)
-            .map_err(|e| PluginError::TransactionUpdateError { msg: e.to_string() })
     }
 
     fn account_data_notifications_enabled(&self) -> bool {
-        self.unwrap_publisher().wants_update_account()
+        self.unwrap_publishers()
+            .iter()
+            .any(|p| p.wants_update_account())
     }
 
     fn transaction_notifications_enabled(&self) -> bool {
-        self.unwrap_publisher().wants_transaction()
+        self.unwrap_publishers()
+            .iter()
+            .any(|p| p.wants_transaction())
     }
 }
 
@@ -194,12 +238,22 @@ impl KafkaPlugin {
         Default::default()
     }
 
-    fn unwrap_publisher(&self) -> &Publisher {
-        self.publisher.as_ref().expect("publisher is unavailable")
+    fn unwrap_publishers(&self) -> Vec<&Publisher> {
+        self.publishers
+            .as_ref()
+            .expect("filtered publishers are unavailable")
+            .iter()
+            .map(|x| &x.publisher)
+            .collect::<Vec<_>>()
     }
 
-    fn unwrap_filter(&self) -> &Filter {
-        self.filter.as_ref().expect("filter is unavailable")
+    fn unwrap_filters(&self) -> Vec<&Filter> {
+        self.publishers
+            .as_ref()
+            .expect("filtered publishers are unavailable")
+            .iter()
+            .map(|x| &x.filter)
+            .collect::<Vec<_>>()
     }
 
     fn unwrap_update_account(account: ReplicaAccountInfoVersions) -> &ReplicaAccountInfoV2 {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -109,8 +109,11 @@ impl GeyserPlugin for KafkaPlugin {
         // NOTE: we trigger this even on account updates that we don't care about
         // since checking if the update interval expired should be fairly cheap.
         // If we see a large overhead we should reconsider
+        let now = std::time::Instant::now();
         for filter in self.unwrap_filters() {
-            filter.get_allowlist().update_from_http_if_needed_async();
+            filter
+                .get_allowlist()
+                .update_from_http_if_needed_async(&now);
         }
 
         if !self

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -76,7 +76,7 @@ impl GeyserPlugin for KafkaPlugin {
             info!("Created rdkafka::FutureProducer");
 
             let publisher = Publisher::new(producer, &config, env_config.name.to_string());
-            let filter = Filter::new(&env_config);
+            let filter = Filter::new(env_config);
             publishers.push(FilteredPublisher { publisher, filter })
         }
         self.publishers = Some(publishers);
@@ -138,11 +138,7 @@ impl GeyserPlugin for KafkaPlugin {
         let mut errors = Vec::new();
         for publisher in publishers {
             if let Err(err) = publisher.update_account(event.clone()) {
-                errors.push(format!(
-                    "Error: {} in {} environment",
-                    err.to_string(),
-                    publisher.env,
-                ));
+                errors.push(format!("Error: {} in {} environment", err, publisher.env,));
             }
         }
         if !errors.is_empty() {
@@ -175,11 +171,7 @@ impl GeyserPlugin for KafkaPlugin {
             };
 
             if let Err(err) = publisher.update_slot_status(event) {
-                errors.push(format!(
-                    "Error: {} in {} environment",
-                    err.to_string(),
-                    publisher.env,
-                ));
+                errors.push(format!("Error: {} in {} environment", err, publisher.env,));
             }
         }
 
@@ -228,11 +220,7 @@ impl GeyserPlugin for KafkaPlugin {
             let event = Self::build_transaction_event(slot, info);
 
             if let Err(err) = publisher.update_transaction(event) {
-                errors.push(format!(
-                    "Error: {} in {} environment",
-                    err.to_string(),
-                    publisher.env,
-                ));
+                errors.push(format!("Error: {} in {} environment", err, publisher.env,));
             }
         }
         if !errors.is_empty() {

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -27,6 +27,7 @@ use {
 };
 
 pub struct Publisher {
+    pub(crate) env: String,
     producer: Producer,
     shutdown_timeout: Duration,
 
@@ -38,8 +39,9 @@ pub struct Publisher {
 }
 
 impl Publisher {
-    pub fn new(producer: Producer, config: &Config) -> Self {
+    pub fn new(producer: Producer, config: &Config, env: String) -> Self {
         Self {
+            env,
             producer,
             shutdown_timeout: Duration::from_millis(config.shutdown_timeout_ms),
             update_account_topic: config.update_account_topic.clone(),


### PR DESCRIPTION
## Summary

Adding environment awareness to Geyser plugin.

## Details

Instead of one URL to get list to of supported programs and one kafka cluster to send updates for them
to we now support multiple, each representing a different environment.

Thus the config will now have to provide a combinatation of  `(listUrl, kafkaConfig)` in the
`environments` collection.

* * *

Quoting the updated config description from the readme:
## Config

The config is specified via the plugin's JSON config file. It contains settings that apply to all
environments and some that are environment specific.

### Environment Config Values

This config needs to be added per environment. Thus using different allow list settings for
different Kafka clusters is possible. Each item in the `environments` array is an `EnvConfig`
and follows the below schema.

* **name** (`String`)
    * Name of the environment
* **kafka** (`HashMap<String, String>`)
    * Kafka [`librdkafka` config options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
* **program_allowlist** (`Vec<String>`)
    * Allowlist of programs to publish.
        * If empty, all accounts are published.
        * If not empty, only accounts owned by programs in this list are published.
* **program_allowlist_url** (`String`)
    * URL to fetch allowlist updates from
    * The file must be json, and with the following schema:
      ```json
      {
        "result": [
            "11111111111111111111111111111111",
            "22222222222222222222222222222222"
        ]
      }
      ```
* **program_allowlist_auth** (`String`)
    * Allowlist Authorization header value.
        * If provided the request to the program_allowlist_url will add an
            'Authorization: <value>' header.
        * A sample auth header value would be 'Bearer my_long_secret_token'.
* **program_allowlist_expiry_sec** (`u64`)
    * Update iterval for allowlist from http url.

### Global Config Values

The below config values are global and apply to all environments. Environment specific settings
are added to the `environments` array.

* **shutdown_timeout_ms** (`u64`)
    * Time the plugin is given to flush out all messages to Kafka
        * and gracefully shutdown upon exit request.
* **update_account_topic** (`String`)
    * Kafka topic to send account updates to.
        * Omit to disable.
* **slot_status_topic** (`String`)
    * Kafka topic to send slot status updates to.
        * Omit to disable.
* **transaction_topic** (`String`)
    * Kafka topic to send transaction updates to.
        * Omit to disable.
* **publish_all_accounts** (`bool`)
    * Publish all accounts on startup.
        * Omit to disable.
* **publish_accounts_without_signature** (`bool`)
    * Publishes account updates even if the txn_signature is not present.
        * This will include account updates that occur without a corresponding
            * transaction, i.e. caused by validator book-keeping.
        * Omit to disable.
* **wrap_messages** (`bool`)
    * Wrap all messages in a unified wrapper object.
        * Omit to disable.
* **environments** (`Vec<EnvConfig>`)
    * Kafka cluster and allow list configs for different environments.
        * See [EnvConfig].

### Example Config

```json
{
  "libpath": "/home/solana/geyser-kafka/target/release/libsolana_accountsdb_plugin_kafka.so",
  "shutdown_timeout_ms": 30000,
  "update_account_topic": "geyser.mainnet.account_update",
  "update_slot_topic": "geyser.mainnet.slot_update",
  "update_transaction_topic": "geyser.mainnet.transaction_update",
  "publish_all_accounts": false,
  "publish_accounts_without_signature": false,
  "wrap_messages": false,
  "environments": [
    {
      "name": "dev",
      "program_allowlist_url": "https://example.com/supported-programs",
      "program_allowlist_auth": "Bearer <dev secret bearer token>",
      "program_allowlist_expiry_sec": 30,
      "kafka": {
        "bootstrap.servers": "dev.bootstrap-server:9092",
        "sasl.username": "<username>",
        "sasl.password": "<base64 encoded password>",
        "sasl.mechanism": "SCRAM-SHA-256",
        "security.protocol": "SASL_SSL",
        "request.required.acks": "1",
        "message.timeout.ms": "30000",
        "compression.type": "lz4",
        "partitioner": "random"
      }
    },
    {
      "name": "stage",
      "program_allowlist_url": "https://example.com/supported-programs",
      "program_allowlist_auth": "Bearer <stage secret bearer token>",
      "program_allowlist_expiry_sec": 15,
      "kafka": {
        "bootstrap.servers": "stage.bootstrap-server:9092",
        "sasl.username": "<username>",
        "sasl.password": "<base64 encoded password>",
        "sasl.mechanism": "SCRAM-SHA-256",
        "security.protocol": "SASL_SSL",
        "request.required.acks": "1",
        "message.timeout.ms": "30000",
        "compression.type": "lz4",
        "partitioner": "random"
      }
    }
  ]
}
```

We assume that the same topics are configured in each kafka cluster.
