### PR TITLE
chore: publisher/filter refactor and update account fix

### DIFF
--- a/src/filtering_publisher.rs
+++ b/src/filtering_publisher.rs
@@ -10,7 +10,9 @@ pub struct FilteringPublisher {
 }
 
 impl FilteringPublisher {
-    pub fn new(publisher: Publisher, filter: Filter) -> Self { Self { publisher, filter } }
+    pub fn new(publisher: Publisher, filter: Filter) -> Self {
+        Self { publisher, filter }
+    }
 
     // -----------------
     // Filter

--- a/src/filtering_publisher.rs
+++ b/src/filtering_publisher.rs
@@ -1,0 +1,56 @@
+use rdkafka::error::KafkaError;
+
+use crate::{
+    allowlist::Allowlist, Filter, Publisher, SlotStatusEvent, TransactionEvent, UpdateAccountEvent,
+};
+
+pub struct FilteringPublisher {
+    publisher: Publisher,
+    filter: Filter,
+}
+
+impl FilteringPublisher {
+    pub fn new(publisher: Publisher, filter: Filter) -> Self { Self { publisher, filter } }
+
+    // -----------------
+    // Filter
+    // -----------------
+    pub fn get_allowlist(&self) -> Allowlist {
+        self.filter.get_allowlist()
+    }
+
+    pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
+        self.filter.wants_account_key(account_key)
+    }
+
+    // -----------------
+    // Publisher
+    // -----------------
+    pub fn env(&self) -> &str {
+        &self.publisher.env
+    }
+
+    pub fn wants_update_account(&self) -> bool {
+        self.publisher.wants_update_account()
+    }
+
+    pub fn wants_slot_status(&self) -> bool {
+        self.publisher.wants_slot_status()
+    }
+
+    pub fn wants_transaction(&self) -> bool {
+        self.publisher.wants_transaction()
+    }
+
+    pub fn update_account(&self, ev: UpdateAccountEvent) -> Result<(), KafkaError> {
+        self.publisher.update_account(ev)
+    }
+
+    pub fn update_slot_status(&self, ev: SlotStatusEvent) -> Result<(), KafkaError> {
+        self.publisher.update_slot_status(ev)
+    }
+
+    pub fn update_transaction(&self, ev: TransactionEvent) -> Result<(), KafkaError> {
+        self.publisher.update_transaction(ev)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod config;
 mod env_config;
 mod event;
 mod filter;
+mod filtering_publisher;
 mod plugin;
 mod publisher;
 
@@ -31,6 +32,7 @@ pub use {
     env_config::EnvConfig,
     event::*,
     filter::Filter,
+    filtering_publisher::FilteringPublisher,
     plugin::KafkaPlugin,
     publisher::Publisher,
 };

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -26,14 +26,9 @@ use {
     std::fmt::{Debug, Formatter},
 };
 
-pub struct FilteredPublisher {
-    publisher: Publisher,
-    filter: Filter,
-}
-
 #[derive(Default)]
 pub struct KafkaPlugin {
-    publishers: Option<Vec<FilteredPublisher>>,
+    publishers: Option<Vec<FilteringPublisher>>,
     publish_all_accounts: bool,
     publish_accounts_without_signature: bool,
 }
@@ -77,7 +72,7 @@ impl GeyserPlugin for KafkaPlugin {
 
             let publisher = Publisher::new(producer, &config, env_config.name.to_string());
             let filter = Filter::new(env_config);
-            publishers.push(FilteredPublisher { publisher, filter })
+            publishers.push(FilteringPublisher::new(publisher, filter))
         }
         self.publishers = Some(publishers);
         info!("Spawned producers");

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -257,7 +257,6 @@ impl KafkaPlugin {
             .collect::<Vec<_>>()
     }
 
-
     fn unwrap_update_account(account: ReplicaAccountInfoVersions) -> &ReplicaAccountInfoV2 {
         match account {
             ReplicaAccountInfoVersions::V0_0_1(_info) => {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -105,17 +105,14 @@ impl GeyserPlugin for KafkaPlugin {
         // since checking if the update interval expired should be fairly cheap.
         // If we see a large overhead we should reconsider
         let now = std::time::Instant::now();
-        for filter in self.unwrap_filters() {
-            filter
+        let publishers = &self.unwrap_publishers();
+        for publisher in publishers {
+            publisher
                 .get_allowlist()
                 .update_from_http_if_needed_async(&now);
         }
 
-        if !self
-            .unwrap_filters()
-            .iter()
-            .any(|p| p.wants_account_key(info.owner))
-        {
+        if !publishers.iter().any(|p| p.wants_account_key(info.owner)) {
             Self::log_ignore_account_update(info);
             return Ok(());
         }
@@ -132,11 +129,14 @@ impl GeyserPlugin for KafkaPlugin {
             txn_signature: info.txn_signature.map(|sig| sig.as_ref().to_owned()),
         };
 
-        let publishers = self.unwrap_publishers();
         let mut errors = Vec::new();
         for publisher in publishers {
+            if !publisher.wants_account_key(info.owner) {
+                continue;
+            }
+
             if let Err(err) = publisher.update_account(event.clone()) {
-                errors.push(format!("Error: {} in {} environment", err, publisher.env,));
+                errors.push(format!("Error: {} in {} environment", err, publisher.env()));
             }
         }
         if !errors.is_empty() {
@@ -154,7 +154,7 @@ impl GeyserPlugin for KafkaPlugin {
         parent: Option<u64>,
         status: PluginSlotStatus,
     ) -> PluginResult<()> {
-        let publishers = self.unwrap_publishers();
+        let publishers = &self.unwrap_publishers();
 
         let mut errors = Vec::new();
         for publisher in publishers {
@@ -169,7 +169,7 @@ impl GeyserPlugin for KafkaPlugin {
             };
 
             if let Err(err) = publisher.update_slot_status(event) {
-                errors.push(format!("Error: {} in {} environment", err, publisher.env,));
+                errors.push(format!("Error: {} in {} environment", err, publisher.env()));
             }
         }
 
@@ -188,8 +188,9 @@ impl GeyserPlugin for KafkaPlugin {
         slot: u64,
     ) -> PluginResult<()> {
         let publishers = self.unwrap_publishers();
-        let mut errors = Vec::new();
         let info = Self::unwrap_transaction(transaction);
+
+        let mut errors = Vec::new();
         for publisher in publishers {
             if !publisher.wants_transaction() {
                 continue;
@@ -202,9 +203,9 @@ impl GeyserPlugin for KafkaPlugin {
                 .iter()
                 .find(|key| {
                     !self
-                        .unwrap_filters()
+                        .unwrap_publishers()
                         .iter()
-                        .any(|f| f.wants_account_key(&key.to_bytes()))
+                        .any(|p| p.wants_account_key(&key.to_bytes()))
                 });
             if maybe_ignored.is_some() {
                 debug!(
@@ -218,7 +219,7 @@ impl GeyserPlugin for KafkaPlugin {
             let event = Self::build_transaction_event(slot, info);
 
             if let Err(err) = publisher.update_transaction(event) {
-                errors.push(format!("Error: {} in {} environment", err, publisher.env,));
+                errors.push(format!("Error: {} in {} environment", err, publisher.env()));
             }
         }
         if !errors.is_empty() {
@@ -248,23 +249,14 @@ impl KafkaPlugin {
         Default::default()
     }
 
-    fn unwrap_publishers(&self) -> Vec<&Publisher> {
+    fn unwrap_publishers(&self) -> Vec<&FilteringPublisher> {
         self.publishers
             .as_ref()
             .expect("filtered publishers are unavailable")
             .iter()
-            .map(|x| &x.publisher)
             .collect::<Vec<_>>()
     }
 
-    fn unwrap_filters(&self) -> Vec<&Filter> {
-        self.publishers
-            .as_ref()
-            .expect("filtered publishers are unavailable")
-            .iter()
-            .map(|x| &x.filter)
-            .collect::<Vec<_>>()
-    }
 
     fn unwrap_update_account(account: ReplicaAccountInfoVersions) -> &ReplicaAccountInfoV2 {
         match account {


### PR DESCRIPTION
## Summary

Improving Publisher/Filter design and now only publishing account updates of a program for
publishers whose filter includes that program.

## Details

`FilteringPublisher` now abstracts `Publisher` and `Filter` and is responsible for forwarding
requests to either of the two. However it represents a unit of both and makes code using it
much easier as it can treat the _filtering_ publisher the same way it treated the _one_ filter
and the _one_ publisher before.

Thus the code using the publisher does not have to worry about associating it with the
appropriate filter.

This PR then also fixes the account updates that _any_ publisher wants (via a matching filter)
going to _all_ publishers. Now only publishers whose filter includes the program of the account
will publish it.
