### PR TITLE
feat: changing key of account update to owner

### DIFF
--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -54,7 +54,7 @@ impl Publisher {
     pub fn update_account(&self, ev: UpdateAccountEvent) -> Result<(), KafkaError> {
         let temp_key;
         let (key, buf) = if self.wrap_messages {
-            temp_key = self.copy_and_prepend(ev.pubkey.as_slice(), 65u8);
+            temp_key = self.copy_and_prepend(ev.owner.as_slice(), 65u8);
             (&temp_key, Self::encode_with_wrapper(Account(Box::new(ev))))
         } else {
             (&ev.owner, ev.encode_to_vec())

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -57,7 +57,7 @@ impl Publisher {
             temp_key = self.copy_and_prepend(ev.pubkey.as_slice(), 65u8);
             (&temp_key, Self::encode_with_wrapper(Account(Box::new(ev))))
         } else {
-            (&ev.pubkey, ev.encode_to_vec())
+            (&ev.owner, ev.encode_to_vec())
         };
         let record = BaseRecord::<Vec<u8>, _>::to(&self.update_account_topic)
             .key(key)


### PR DESCRIPTION
## Summary

Change account update event key to account _owner_ (the program) which results in Kafka events
being partitioned by program which improves Flash performance.

**NOTE**: This is a very quick _fix_. Should we want to make this configurable instead we
should hold off on merging and implement this _properly_ allowing to specify in the config
which pubkey to use for the key of the event.

## Details

Flash downloads IDLs for each program it processes and also needs separate mongodb update
requests for each program collection. Thus grouping accounts of the same program together as
much as possible improves our performance.

