### PR TITLE
feat: update account topic overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ are added to the `environments` array.
 * **transaction_topic** (`String`)
     * Kafka topic to send transaction updates to.
         * Omit to disable.
+* **update_account_topic_overrides** (`HashMap<String, HashSet<String>>`)
+    * Kafka topic overrides to send specific account updates to. 
+      * Omit to disable. 
+      * The keys are the alternate topics and the value is a collection of program addresses.
+        If an account's owner matches one of those addresses its updates are sent to the
+        alternative topic instead of `[update_account_topic]`.
 * **publish_all_accounts** (`bool`)
     * Publish all accounts on startup.
         * Omit to disable.
@@ -109,6 +115,12 @@ are added to the `environments` array.
   "update_account_topic": "geyser.mainnet.account_update",
   "update_slot_topic": "geyser.mainnet.slot_update",
   "update_transaction_topic": "geyser.mainnet.transaction_update",
+  "update_account_topic_overrides": {
+    "geyser.mainnet.spl.account_update": [
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+    ]
+  },
   "publish_all_accounts": false,
   "publish_accounts_without_signature": false,
   "wrap_messages": false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,18 @@ pub struct Config {
     /// The keys are the alternate topics and the value is a collection of program
     /// addresses. If an account's owner matches one of those addresses its updates
     /// are sent to the alternative topic instead of [update_account_topic].
+    ///
+    /// ### Example
+    /// ```json
+    /// {
+    ///   "update_account_topic_overrides": {
+    ///      "geyser.mainnet.spl.account_update": [
+    ///         "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    ///         "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+    ///      ]
+    ///    }
+    /// }
+    /// ```
     #[serde(default)]
     pub update_account_topic_overrides: HashMap<String, HashSet<String>>,
 

--- a/test/fixtures/configs/single-env-topic-overrides.json
+++ b/test/fixtures/configs/single-env-topic-overrides.json
@@ -1,0 +1,33 @@
+{
+  "libpath": "./target/debug/libsolana_accountsdb_plugin_kafka.dylib",
+  "shutdown_timeout_ms": 30000,
+  "update_account_topic": "geyser.mainnet.account_update",
+  "update_account_topic_overrides": {
+    "geyser.mainnet.spl.account_update": [
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+    ]
+  },
+  "publish_all_accounts": false,
+  "publish_accounts_without_signature": false,
+  "wrap_messages": false,
+  "environments": [
+    {
+      "name": "dev",
+      "program_allowlist_url": "https://some.upstash.io/smembers/supported-programs",
+      "program_allowlist_auth": "Bearer bearertoken",
+      "program_allowlist_expiry_sec": 15,
+      "kafka": {
+        "bootstrap.servers": "some-us1-kafka.upstash.io:9092",
+        "sasl.username": "sasl.user",
+        "sasl.password": "sasl.pass",
+        "sasl.mechanism": "SCRAM-SHA-256",
+        "security.protocol": "SASL_SSL",
+        "request.required.acks": "1",
+        "message.timeout.ms": "30000",
+        "compression.type": "lz4",
+        "partitioner": "murmur2_random"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **update_account_topic_overrides** (`HashMap<String, HashSet<String>>`) 

## Details

The keys are the alternate topics and the value is a collection of program addresses. If
an account's owner matches one of those addresses its updates are sent to the alternative
topic instead of `update_account_topic`.

### Example Config

```json
{
  "libpath": "./target/debug/libsolana_accountsdb_plugin_kafka.dylib",
  "shutdown_timeout_ms": 30000,
  "update_account_topic": "geyser.mainnet.account_update",
  "update_account_topic_overrides": {
    "geyser.mainnet.spl.account_update": [
      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
      "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
    ]
  },
  "publish_all_accounts": false,
  [ .. ]
}
````
