### PR TITLE
feat: support local http config to publish events to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1588,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2036,7 +2036,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2212,6 +2212,7 @@ dependencies = [
  "solana-logger",
  "solana-program",
  "solana-transaction-status",
+ "thiserror",
  "toml_datetime",
  "toml_edit",
  "ureq",
@@ -2650,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2683,22 +2684,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2985,7 +2986,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -3019,7 +3020,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3277,7 +3278,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ toml_datetime = { version = "=0.6.1" }                  # 0.6.2 requires rust 1.
 toml_edit = { version = "=0.19.8" }                     # 0.19.9 requires rust 1.64.0
 winnow = { version = "=0.4.1" }                         # 0.4.2 requires rust 1.64.0
 ureq = "2.5.0"
+thiserror = "1.0.44"
 
 [dev-dependencies]
 mockito = "0.31.1"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ This config needs to be added per environment. Thus using different allow list s
 different Kafka clusters is possible. Each item in the `environments` array is an `EnvConfig`
 and follows the below schema.
 
+An environment config for local development and testing also can be provided, please see 
+_Local Environment Config Values_ below.
+
 * **name** (`String`)
     * Name of the environment
 * **kafka** (`HashMap<String, String>`)
@@ -158,10 +161,42 @@ are added to the `environments` array.
         "compression.type": "lz4",
         "partitioner": "random"
       }
+    },
+    {
+      "name": "local",
+      "url": "http://localhost:9999",
+      "include_system_accounts": false
     }
   ]
 }
 ```
+### Local Environment Config Values
+
+In order to facilitate local development and testing the plugin itself a `local` environment
+can be configured. Mainly it switches out how events are published. Instead of publishing to
+Kafka they are published to the configured URL using the respective topic as the path appended
+to that URL.
+
+**NOTE**: this should only be used when running the Geyser plugin with a local solana test
+validator as it publishes events over HTTP synchronously which will cause performance issues
+when used with a live cluster.
+
+In the above example account updates would be published to
+`http://localhost:9999/geyser.mainnet.account_update`.
+
+Tools like [geyser-store](https://github.com/ironforge-cloud/geyser-store) can be used to to
+trace and store events locally for further analysis or to allow checking them in tests.
+
+* **name**: The name of the environment.
+* **program_allowlist**: A list of programs whose accounts should be published. If empty, all
+  accounts are published including system program accounts unless `include_system_accounts` is
+  `false`
+* **url**: The URL to publish to.
+* **include_system_accounts**: If `true`, then all system accounts are included when no `program_allowlist` is set. Otherwise, the following accounts are ignored:
+    * System Program: `11111111111111111111111111111111`
+    * BPF Loader: `BPFLoaderUpgradeab1e1111111111111111111111`
+    * Vote Program: `Vote111111111111111111111111111111111111111`
+    * Config Program: `Config1111111111111111111111111111111111111`
 
 ### Message Keys
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "1.63.0"
-components = ["clippy", "rustfmt"]
-targets = []
-profile = "minimal"

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -78,6 +78,7 @@ impl Allowlist {
 
                 Self::new_from_vec(config.program_allowlist.clone())
             }
+            EnvConfig::Local(config) => Self::new_from_vec(config.program_allowlist.clone()),
         }
     }
 
@@ -299,18 +300,20 @@ impl Allowlist {
 mod tests {
     use std::{thread, time::Duration};
 
+    use crate::env_config::EnvConfigKafka;
+
     use super::*;
     #[test]
     fn test_allowlist_from_vec() {
-        let config = EnvConfig {
+        let config = EnvConfig::Kafka(EnvConfigKafka {
             program_allowlist: vec![
                 "Sysvar1111111111111111111111111111111111111".to_owned(),
                 "Vote111111111111111111111111111111111111111".to_owned(),
             ],
-            ..EnvConfig::default()
-        };
+            ..EnvConfigKafka::default()
+        });
 
-        let allowlist = Allowlist::new_from_vec(config.program_allowlist).unwrap();
+        let allowlist = Allowlist::new_from_vec(config.program_allowlist().to_vec()).unwrap();
         assert_eq!(allowlist.len(), 2);
 
         assert!(allowlist.wants_program(
@@ -340,12 +343,12 @@ mod tests {
             .with_body("{\"result\":[\"Sysvar1111111111111111111111111111111111111\",\"Vote111111111111111111111111111111111111111\"]}")
             .create();
 
-        let config = EnvConfig {
+        let config = EnvConfig::Kafka(EnvConfigKafka {
             program_allowlist_url: [mockito::server_url(), "/allowlist.txt".to_owned()].join(""),
             program_allowlist_expiry_sec: 3,
             program_allowlist: vec!["WormT3McKhFJ2RkiGpdw9GKvNCrB2aB54gb2uV9MfQC".to_owned()],
-            ..EnvConfig::default()
-        };
+            ..EnvConfigKafka::default()
+        });
 
         let mut allowlist = Allowlist::new_from_config(&config).unwrap();
         let now = std::time::Instant::now();

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -37,45 +37,48 @@ struct RemoteAllowlist {
     program_allowlist: Vec<String>,
 }
 
-// new() is a constructor for Allowlist
 impl Allowlist {
     pub fn len(&self) -> usize {
         let list = self.list.lock().unwrap();
         list.len()
     }
     pub fn new_from_config(config: &EnvConfig) -> PluginResult<Self> {
-        // Users can provide a URL to fetch the allow list from
-        if !config.program_allowlist_url.is_empty() {
-            let mut this = Self::new_from_http(
-                &config.program_allowlist_url.clone(),
-                &config.program_allowlist_auth.clone(),
-                std::time::Duration::from_secs(config.program_allowlist_expiry_sec),
-            )
-            .unwrap();
+        match config {
+            EnvConfig::Kafka(config) => {
+                // Users can provide a URL to fetch the allow list from
+                if !config.program_allowlist_url.is_empty() {
+                    let mut this = Self::new_from_http(
+                        &config.program_allowlist_url.clone(),
+                        &config.program_allowlist_auth.clone(),
+                        std::time::Duration::from_secs(config.program_allowlist_expiry_sec),
+                    )
+                    .unwrap();
 
-            if !config.program_allowlist.is_empty() {
-                // The allowlist to start with can be defined in the config
-                this.push_vec(config.program_allowlist.clone());
-            } else {
-                // Otherwise, fetch it from the provided url
-                this.init_list_from_http_blocking(
-                    &config.program_allowlist_url,
-                    &config.program_allowlist_auth,
-                )?;
+                    if !config.program_allowlist.is_empty() {
+                        // The allowlist to start with can be defined in the config
+                        this.push_vec(config.program_allowlist.clone());
+                    } else {
+                        // Otherwise, fetch it from the provided url
+                        this.init_list_from_http_blocking(
+                            &config.program_allowlist_url,
+                            &config.program_allowlist_auth,
+                        )?;
+                    }
+
+                    return Ok(this);
+                }
+
+                // If no url is provided, then the allowlist needs to be defined in the config
+                if config.program_allowlist.is_empty() {
+                    return Err(PluginError::Custom(Box::new(SimpleError::new(
+                        "Need to provide a program allowlist provided or a URL to fetch it from"
+                            .to_string(),
+                    ))));
+                }
+
+                Self::new_from_vec(config.program_allowlist.clone())
             }
-
-            return Ok(this);
         }
-
-        // If no url is provided, then the allowlist needs to be defined in the config
-        if config.program_allowlist.is_empty() {
-            return Err(PluginError::Custom(Box::new(SimpleError::new(
-                "Need to provide a program allowlist provided or a URL to fetch it from"
-                    .to_string(),
-            ))));
-        }
-
-        Self::new_from_vec(config.program_allowlist.clone())
     }
 
     /// new_from_vec creates a new Allowlist from a vector of program ids.

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,8 +106,8 @@ impl Config {
         let mut this: Self = serde_json::from_reader(file)
             .map_err(|e| GeyserPluginError::ConfigFileReadError { msg: e.to_string() })?;
         for env_config in this.environments.iter_mut() {
-            match env_config {
-                EnvConfig::Kafka(env_config) => env_config.fill_defaults(),
+            if let EnvConfig::Kafka(env_config) = env_config {
+                env_config.fill_defaults();
             }
         }
         Ok(this)

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,7 +106,9 @@ impl Config {
         let mut this: Self = serde_json::from_reader(file)
             .map_err(|e| GeyserPluginError::ConfigFileReadError { msg: e.to_string() })?;
         for env_config in this.environments.iter_mut() {
-            env_config.fill_defaults();
+            match env_config {
+                EnvConfig::Kafka(env_config) => env_config.fill_defaults(),
+            }
         }
         Ok(this)
     }

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -7,9 +7,15 @@ use serde::Deserialize;
 
 use crate::Producer;
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum EnvConfig {
+    Kafka(EnvConfigKafka),
+}
+
 /// Environment specific config.
 #[derive(Deserialize)]
-pub struct EnvConfig {
+pub struct EnvConfigKafka {
     /// Name of the environment
     #[serde(default)]
     pub name: String,
@@ -48,7 +54,7 @@ pub struct EnvConfig {
     pub program_allowlist_expiry_sec: u64,
 }
 
-impl Default for EnvConfig {
+impl Default for EnvConfigKafka {
     fn default() -> Self {
         Self {
             program_allowlist_expiry_sec: 60,
@@ -61,7 +67,7 @@ impl Default for EnvConfig {
     }
 }
 
-impl EnvConfig {
+impl EnvConfigKafka {
     /// Create rdkafka::FutureProducer from config.
     pub fn producer(&self) -> KafkaResult<Producer> {
         let mut config = ClientConfig::new();

--- a/src/env_config/config_kafka.rs
+++ b/src/env_config/config_kafka.rs
@@ -7,12 +7,6 @@ use serde::Deserialize;
 
 use crate::Producer;
 
-#[derive(Deserialize)]
-#[serde(untagged)]
-pub enum EnvConfig {
-    Kafka(EnvConfigKafka),
-}
-
 /// Environment specific config.
 #[derive(Deserialize)]
 pub struct EnvConfigKafka {

--- a/src/env_config/config_local.rs
+++ b/src/env_config/config_local.rs
@@ -1,0 +1,24 @@
+use serde::Deserialize;
+
+/// Environment specific config.
+#[derive(Deserialize)]
+pub struct EnvConfigLocal {
+    /// Name of the environment
+    #[serde(default)]
+    pub name: String,
+
+    /// Allowlist of programs to publish.
+    /// If empty, all accounts are published since we are using this locally.
+    /// If not empty, only accounts owned by programs in this list are published.
+    #[serde(default)]
+    pub program_allowlist: Vec<String>,
+}
+
+impl Default for EnvConfigLocal {
+    fn default() -> Self {
+        Self {
+            name: Default::default(),
+            program_allowlist: Default::default(),
+        }
+    }
+}

--- a/src/env_config/config_local.rs
+++ b/src/env_config/config_local.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 /// Environment specific config for local development.
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 pub struct EnvConfigLocal {
     /// Name of the environment
     #[serde(default)]
@@ -9,20 +9,20 @@ pub struct EnvConfigLocal {
 
     /// Allowlist of programs to publish.
     /// If empty, all accounts are published since we are using this locally.
-    /// If not empty, only accounts owned by programs in this list are published.
+    /// If not empty, only accounts owned by programs in this list are published including system
+    /// program accounts unless [include_system_accounts] is `false`
     #[serde(default)]
     pub program_allowlist: Vec<String>,
 
     /// URL to publish to.
     pub url: String,
-}
 
-impl Default for EnvConfigLocal {
-    fn default() -> Self {
-        Self {
-            name: Default::default(),
-            program_allowlist: Default::default(),
-            url: Default::default(),
-        }
-    }
+    /// If `true` then all system accounts are included when no [program_allowlist] is set
+    /// Otherwise the following are ignored:
+    /// - System Program: 11111111111111111111111111111111
+    /// - BPF Loader:     BPFLoaderUpgradeab1e11111111111111111111111
+    /// - Vote Program:   Vote111111111111111111111111111111111111111
+    /// - Config Program: Config1111111111111111111111111111111111111
+    #[serde(default)]
+    pub include_system_accounts: bool,
 }

--- a/src/env_config/config_local.rs
+++ b/src/env_config/config_local.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-/// Environment specific config.
+/// Environment specific config for local development.
 #[derive(Deserialize)]
 pub struct EnvConfigLocal {
     /// Name of the environment
@@ -12,6 +12,9 @@ pub struct EnvConfigLocal {
     /// If not empty, only accounts owned by programs in this list are published.
     #[serde(default)]
     pub program_allowlist: Vec<String>,
+
+    /// URL to publish to.
+    pub url: String,
 }
 
 impl Default for EnvConfigLocal {
@@ -19,6 +22,7 @@ impl Default for EnvConfigLocal {
         Self {
             name: Default::default(),
             program_allowlist: Default::default(),
+            url: Default::default(),
         }
     }
 }

--- a/src/env_config/mod.rs
+++ b/src/env_config/mod.rs
@@ -1,0 +1,9 @@
+mod config_kafka;
+pub use config_kafka::EnvConfigKafka;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum EnvConfig {
+    Kafka(EnvConfigKafka),
+}

--- a/src/env_config/mod.rs
+++ b/src/env_config/mod.rs
@@ -1,9 +1,21 @@
 mod config_kafka;
+mod config_local;
 pub use config_kafka::EnvConfigKafka;
+pub use config_local::EnvConfigLocal;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum EnvConfig {
     Kafka(EnvConfigKafka),
+    Local(EnvConfigLocal),
+}
+
+impl EnvConfig {
+    pub fn program_allowlist(&self) -> &[String] {
+        match self {
+            EnvConfig::Kafka(c) => &c.program_allowlist,
+            EnvConfig::Local(c) => &c.program_allowlist,
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,19 @@
+use std::array::TryFromSliceError;
+use thiserror::Error;
+
+pub type PluginResult<T> = Result<T, PluginError>;
+
+#[derive(Error, Debug)]
+pub enum PluginError {
+    #[error("TryFromSliceError ({0})")]
+    TryFromSliceError(#[from] TryFromSliceError),
+
+    #[error("SerdeJsonError ({0})")]
+    SerdeJsonError(#[from] serde_json::Error),
+
+    #[error("KafkaError ({0})")]
+    KafkaError(#[from] rdkafka::error::KafkaError),
+
+    #[error("UreqError ({0})")]
+    UreqError(#[from] ureq::Error),
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -31,6 +31,10 @@ impl Filter {
         self.program_allowlist.clone()
     }
 
+    pub fn allow_list_is_empty(&self) -> bool {
+        self.program_allowlist.len() == 0
+    }
+
     pub fn wants_account_key(
         &self,
         account_key: &[u8],

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -31,11 +31,15 @@ impl Filter {
         self.program_allowlist.clone()
     }
 
-    pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
+    pub fn wants_account_key(
+        &self,
+        account_key: &[u8],
+        wants_all_on_empty_allow_list: bool,
+    ) -> bool {
         if self.program_allowlist.len() > 0 {
             self.program_allowlist.wants_program(account_key)
         } else {
-            false
+            wants_all_on_empty_allow_list
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use solana_geyser_plugin_interface::geyser_plugin_interface::GeyserPlugin;
 mod allowlist;
 mod config;
 mod env_config;
+mod errors;
 mod event;
 mod filter;
 mod plugin;
@@ -29,6 +30,7 @@ mod publisher;
 pub use {
     config::{Config, Producer},
     env_config::EnvConfig,
+    errors::*,
     event::*,
     filter::Filter,
     plugin::KafkaPlugin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ mod config;
 mod env_config;
 mod event;
 mod filter;
-mod filtering_publisher;
 mod plugin;
 mod publisher;
 
@@ -32,9 +31,8 @@ pub use {
     env_config::EnvConfig,
     event::*,
     filter::Filter,
-    filtering_publisher::FilteringPublisher,
     plugin::KafkaPlugin,
-    publisher::Publisher,
+    publisher::FilteringPublisher,
 };
 
 #[no_mangle]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -67,16 +67,21 @@ impl GeyserPlugin for KafkaPlugin {
 
         let mut publishers = Vec::new();
         for env_config in &config.environments {
-            let producer = env_config
-                .producer()
-                .map_err(|e| PluginError::Custom(Box::new(e)))?;
-            info!("Created rdkafka::FutureProducer");
-
-            let publisher = KafkaPublisher::new(producer, &config, env_config.name.to_string());
             let filter = Filter::new(env_config);
-            let publisher =
-                Publisher::FilteringPublisher(FilteringPublisher::new(publisher, filter));
-            publishers.push(publisher);
+            match env_config {
+                EnvConfig::Kafka(env_config) => {
+                    let producer = env_config
+                        .producer()
+                        .map_err(|e| PluginError::Custom(Box::new(e)))?;
+                    info!("Created rdkafka::FutureProducer");
+
+                    let publisher =
+                        KafkaPublisher::new(producer, &config, env_config.name.to_string());
+                    let publisher =
+                        Publisher::FilteringPublisher(FilteringPublisher::new(publisher, filter));
+                    publishers.push(publisher);
+                }
+            }
         }
         self.publishers = Some(publishers);
         info!("Spawned producers");

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -81,6 +81,9 @@ impl GeyserPlugin for KafkaPlugin {
                         Publisher::FilteringPublisher(FilteringPublisher::new(publisher, filter));
                     publishers.push(publisher);
                 }
+                EnvConfig::Local(_env_config) => {
+                    todo!()
+                }
             }
         }
         self.publishers = Some(publishers);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::publisher::{kafka_publisher::KafkaPublisher, Publisher};
+use crate::publisher::{kafka_publisher::KafkaPublisher, LocalPublisher, Publisher};
 
 use {
     crate::*,
@@ -81,8 +81,18 @@ impl GeyserPlugin for KafkaPlugin {
                         Publisher::FilteringPublisher(FilteringPublisher::new(publisher, filter));
                     publishers.push(publisher);
                 }
-                EnvConfig::Local(_env_config) => {
-                    todo!()
+                EnvConfig::Local(env_config) => {
+                    let publisher = Publisher::LocalPublisher(LocalPublisher::new(
+                        filter,
+                        &config,
+                        env_config.name.to_string(),
+                        env_config.url.clone(),
+                    ));
+                    info!(
+                        "Created local http publisher '{}', publishing to '{}'",
+                        env_config.name, env_config.url
+                    );
+                    publishers.push(publisher);
                 }
             }
         }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -87,6 +87,7 @@ impl GeyserPlugin for KafkaPlugin {
                         &config,
                         env_config.name.to_string(),
                         env_config.url.clone(),
+                        env_config.include_system_accounts,
                     ));
                     info!(
                         "Created local http publisher '{}', publishing to '{}'",

--- a/src/publisher/filtering_publisher.rs
+++ b/src/publisher/filtering_publisher.rs
@@ -22,7 +22,7 @@ impl FilteringPublisher {
     }
 
     pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
-        self.filter.wants_account_key(account_key)
+        self.filter.wants_account_key(account_key, false)
     }
 
     // -----------------

--- a/src/publisher/filtering_publisher.rs
+++ b/src/publisher/filtering_publisher.rs
@@ -1,16 +1,16 @@
 use rdkafka::error::KafkaError;
 
-use crate::{
-    allowlist::Allowlist, Filter, Publisher, SlotStatusEvent, TransactionEvent, UpdateAccountEvent,
-};
+use crate::{allowlist::Allowlist, Filter, SlotStatusEvent, TransactionEvent, UpdateAccountEvent};
+
+use super::kafka_publisher::KafkaPublisher;
 
 pub struct FilteringPublisher {
-    publisher: Publisher,
+    publisher: KafkaPublisher,
     filter: Filter,
 }
 
 impl FilteringPublisher {
-    pub fn new(publisher: Publisher, filter: Filter) -> Self {
+    pub fn new(publisher: KafkaPublisher, filter: Filter) -> Self {
         Self { publisher, filter }
     }
 

--- a/src/publisher/kafka_publisher.rs
+++ b/src/publisher/kafka_publisher.rs
@@ -28,7 +28,7 @@ use {
     std::time::Duration,
 };
 
-pub struct Publisher {
+pub struct KafkaPublisher {
     pub(crate) env: String,
     producer: Producer,
     shutdown_timeout: Duration,
@@ -41,7 +41,7 @@ pub struct Publisher {
     wrap_messages: bool,
 }
 
-impl Publisher {
+impl KafkaPublisher {
     pub fn new(producer: Producer, config: &Config, env: String) -> Self {
         Self {
             env,
@@ -132,7 +132,7 @@ impl Publisher {
     }
 }
 
-impl Drop for Publisher {
+impl Drop for KafkaPublisher {
     fn drop(&mut self) {
         if let Err(e) = self.producer.flush(self.shutdown_timeout) {
             error!("Failed to flush producer: {}", e);

--- a/src/publisher/local_publisher.rs
+++ b/src/publisher/local_publisher.rs
@@ -3,7 +3,7 @@ use crate::{
     UpdateAccountEvent,
 };
 
-use log::info;
+use log::debug;
 use serde::Serialize;
 
 // -----------------
@@ -112,9 +112,10 @@ impl LocalPublisher {
     fn publish_event<T: Serialize>(&self, path: &str, ev: &T) -> PluginResult<()> {
         let payload = serde_json::to_vec(ev)?;
         let uri = format!("{}/{}", self.root_url, path);
-        let res = ureq::post(&uri).send_bytes(&payload)?;
-        info!("Published event to {}", uri);
-        info!("res {res:#?}");
+        let res = ureq::post(&uri)
+            .set("Content-Type", "application/json")
+            .send_bytes(&payload)?;
+        debug!("Published event to {}", uri);
         Ok(())
     }
 }

--- a/src/publisher/local_publisher.rs
+++ b/src/publisher/local_publisher.rs
@@ -51,7 +51,6 @@ pub struct LocalPublisher {
 }
 
 impl LocalPublisher {
-    #[allow(unused)]
     pub fn new(filter: Filter, config: &Config, env: String, root_url: String) -> Self {
         Self {
             env,

--- a/src/publisher/local_publisher.rs
+++ b/src/publisher/local_publisher.rs
@@ -1,15 +1,66 @@
-use crate::{allowlist::Allowlist, Filter, SlotStatusEvent, TransactionEvent, UpdateAccountEvent};
+use crate::{
+    allowlist::Allowlist, Config, Filter, PluginResult, SlotStatusEvent, TransactionEvent,
+    UpdateAccountEvent,
+};
 
-use rdkafka::error::KafkaError;
+use log::info;
+use serde::Serialize;
 
+// -----------------
+// Serializable Events
+// -----------------
+#[derive(Serialize)]
+pub struct SerializableUpdateAccountEvent {
+    slot: u64,
+    pubkey: Vec<u8>,
+    lamports: u64,
+    owner: Vec<u8>,
+    executable: bool,
+    rent_epoch: u64,
+    data: Vec<u8>,
+    write_version: u64,
+    txn_signature: Option<Vec<u8>>,
+}
+
+impl From<UpdateAccountEvent> for SerializableUpdateAccountEvent {
+    fn from(ev: UpdateAccountEvent) -> Self {
+        Self {
+            slot: ev.slot,
+            pubkey: ev.pubkey,
+            lamports: ev.lamports,
+            owner: ev.owner,
+            executable: ev.executable,
+            rent_epoch: ev.rent_epoch,
+            data: ev.data,
+            write_version: ev.write_version,
+            txn_signature: ev.txn_signature,
+        }
+    }
+}
+
+// -----------------
+// LocalPublisher
+// -----------------
 pub struct LocalPublisher {
+    pub(crate) env: String,
     filter: Filter,
+    update_account_path: String,
+    update_slot_status_path: String,
+    update_transaction_path: String,
+    root_url: String,
 }
 
 impl LocalPublisher {
     #[allow(unused)]
-    pub fn new(filter: Filter) -> Self {
-        Self { filter }
+    pub fn new(filter: Filter, config: &Config, env: String, root_url: String) -> Self {
+        Self {
+            env,
+            update_account_path: config.update_account_topic.clone(),
+            update_slot_status_path: config.slot_status_topic.clone(),
+            update_transaction_path: config.transaction_topic.clone(),
+            root_url,
+            filter,
+        }
     }
 
     // -----------------
@@ -20,37 +71,51 @@ impl LocalPublisher {
     }
 
     pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
-        self.filter.wants_account_key(account_key)
+        self.filter.wants_account_key(account_key, true)
     }
 
     // -----------------
     // Publisher
     // -----------------
     pub fn env(&self) -> &str {
-        todo!()
+        self.env.as_str()
     }
 
     pub fn wants_update_account(&self) -> bool {
-        todo!()
+        !self.update_account_path.is_empty()
     }
 
     pub fn wants_slot_status(&self) -> bool {
-        todo!()
+        !self.update_slot_status_path.is_empty()
     }
 
     pub fn wants_transaction(&self) -> bool {
-        todo!()
+        !self.update_transaction_path.is_empty()
     }
 
-    pub fn update_account(&self, _ev: UpdateAccountEvent) -> Result<(), KafkaError> {
-        todo!()
+    pub fn update_account(&self, ev: UpdateAccountEvent) -> PluginResult<()> {
+        self.publish_event(
+            &self.update_account_path,
+            &SerializableUpdateAccountEvent::from(ev),
+        )
     }
 
-    pub fn update_slot_status(&self, _ev: SlotStatusEvent) -> Result<(), KafkaError> {
+    pub fn update_slot_status(&self, _ev: SlotStatusEvent) -> PluginResult<()> {
         todo!()
+        // self.publish_event(&self.update_slot_status_path, &ev)
     }
 
-    pub fn update_transaction(&self, _ev: TransactionEvent) -> Result<(), KafkaError> {
+    pub fn update_transaction(&self, _ev: TransactionEvent) -> PluginResult<()> {
         todo!()
+        // self.publish_event(&self.update_transaction_path, &ev)
+    }
+
+    fn publish_event<T: Serialize>(&self, path: &str, ev: &T) -> PluginResult<()> {
+        let payload = serde_json::to_vec(ev)?;
+        let uri = format!("{}/{}", self.root_url, path);
+        let res = ureq::post(&uri).send_bytes(&payload)?;
+        info!("Published event to {}", uri);
+        info!("res {res:#?}");
+        Ok(())
     }
 }

--- a/src/publisher/local_publisher.rs
+++ b/src/publisher/local_publisher.rs
@@ -1,0 +1,56 @@
+use crate::{allowlist::Allowlist, Filter, SlotStatusEvent, TransactionEvent, UpdateAccountEvent};
+
+use rdkafka::error::KafkaError;
+
+pub struct LocalPublisher {
+    filter: Filter,
+}
+
+impl LocalPublisher {
+    #[allow(unused)]
+    pub fn new(filter: Filter) -> Self {
+        Self { filter }
+    }
+
+    // -----------------
+    // Filter
+    // -----------------
+    pub fn get_allowlist(&self) -> Allowlist {
+        self.filter.get_allowlist()
+    }
+
+    pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
+        self.filter.wants_account_key(account_key)
+    }
+
+    // -----------------
+    // Publisher
+    // -----------------
+    pub fn env(&self) -> &str {
+        todo!()
+    }
+
+    pub fn wants_update_account(&self) -> bool {
+        todo!()
+    }
+
+    pub fn wants_slot_status(&self) -> bool {
+        todo!()
+    }
+
+    pub fn wants_transaction(&self) -> bool {
+        todo!()
+    }
+
+    pub fn update_account(&self, _ev: UpdateAccountEvent) -> Result<(), KafkaError> {
+        todo!()
+    }
+
+    pub fn update_slot_status(&self, _ev: SlotStatusEvent) -> Result<(), KafkaError> {
+        todo!()
+    }
+
+    pub fn update_transaction(&self, _ev: TransactionEvent) -> Result<(), KafkaError> {
+        todo!()
+    }
+}

--- a/src/publisher/mod.rs
+++ b/src/publisher/mod.rs
@@ -2,10 +2,11 @@ mod filtering_publisher;
 pub mod kafka_publisher;
 mod local_publisher;
 
-use crate::{allowlist::Allowlist, SlotStatusEvent, TransactionEvent, UpdateAccountEvent};
+use crate::{
+    allowlist::Allowlist, PluginResult, SlotStatusEvent, TransactionEvent, UpdateAccountEvent,
+};
 pub use filtering_publisher::FilteringPublisher;
 pub use local_publisher::LocalPublisher;
-use rdkafka::error::KafkaError;
 
 pub enum Publisher {
     FilteringPublisher(FilteringPublisher),
@@ -62,24 +63,24 @@ impl Publisher {
         }
     }
 
-    pub fn update_account(&self, ev: UpdateAccountEvent) -> Result<(), KafkaError> {
-        match self {
-            Publisher::FilteringPublisher(p) => p.update_account(ev),
-            Publisher::LocalPublisher(p) => p.update_account(ev),
-        }
+    pub fn update_account(&self, ev: UpdateAccountEvent) -> PluginResult<()> {
+        Ok(match self {
+            Publisher::FilteringPublisher(p) => p.update_account(ev)?,
+            Publisher::LocalPublisher(p) => p.update_account(ev)?,
+        })
     }
 
-    pub fn update_slot_status(&self, ev: SlotStatusEvent) -> Result<(), KafkaError> {
-        match self {
-            Publisher::FilteringPublisher(p) => p.update_slot_status(ev),
-            Publisher::LocalPublisher(p) => p.update_slot_status(ev),
-        }
+    pub fn update_slot_status(&self, ev: SlotStatusEvent) -> PluginResult<()> {
+        Ok(match self {
+            Publisher::FilteringPublisher(p) => p.update_slot_status(ev)?,
+            Publisher::LocalPublisher(p) => p.update_slot_status(ev)?,
+        })
     }
 
-    pub fn update_transaction(&self, ev: TransactionEvent) -> Result<(), KafkaError> {
-        match self {
-            Publisher::FilteringPublisher(p) => p.update_transaction(ev),
-            Publisher::LocalPublisher(p) => p.update_transaction(ev),
-        }
+    pub fn update_transaction(&self, ev: TransactionEvent) -> PluginResult<()> {
+        Ok(match self {
+            Publisher::FilteringPublisher(p) => p.update_transaction(ev)?,
+            Publisher::LocalPublisher(p) => p.update_transaction(ev)?,
+        })
     }
 }

--- a/src/publisher/mod.rs
+++ b/src/publisher/mod.rs
@@ -64,23 +64,26 @@ impl Publisher {
     }
 
     pub fn update_account(&self, ev: UpdateAccountEvent) -> PluginResult<()> {
-        Ok(match self {
+        match self {
             Publisher::FilteringPublisher(p) => p.update_account(ev)?,
             Publisher::LocalPublisher(p) => p.update_account(ev)?,
-        })
+        }
+        Ok(())
     }
 
     pub fn update_slot_status(&self, ev: SlotStatusEvent) -> PluginResult<()> {
-        Ok(match self {
+        match self {
             Publisher::FilteringPublisher(p) => p.update_slot_status(ev)?,
             Publisher::LocalPublisher(p) => p.update_slot_status(ev)?,
-        })
+        }
+        Ok(())
     }
 
     pub fn update_transaction(&self, ev: TransactionEvent) -> PluginResult<()> {
-        Ok(match self {
+        match self {
             Publisher::FilteringPublisher(p) => p.update_transaction(ev)?,
             Publisher::LocalPublisher(p) => p.update_transaction(ev)?,
-        })
+        }
+        Ok(())
     }
 }

--- a/src/publisher/mod.rs
+++ b/src/publisher/mod.rs
@@ -1,12 +1,16 @@
 mod filtering_publisher;
 pub mod kafka_publisher;
-pub use filtering_publisher::FilteringPublisher;
-use rdkafka::error::KafkaError;
+mod local_publisher;
 
 use crate::{allowlist::Allowlist, SlotStatusEvent, TransactionEvent, UpdateAccountEvent};
+pub use filtering_publisher::FilteringPublisher;
+pub use local_publisher::LocalPublisher;
+use rdkafka::error::KafkaError;
 
 pub enum Publisher {
     FilteringPublisher(FilteringPublisher),
+    #[allow(unused)]
+    LocalPublisher(LocalPublisher),
 }
 
 impl Publisher {
@@ -16,12 +20,14 @@ impl Publisher {
     pub fn get_allowlist(&self) -> Allowlist {
         match self {
             Publisher::FilteringPublisher(p) => p.get_allowlist(),
+            Publisher::LocalPublisher(p) => p.get_allowlist(),
         }
     }
 
     pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
         match self {
             Publisher::FilteringPublisher(p) => p.wants_account_key(account_key),
+            Publisher::LocalPublisher(p) => p.wants_account_key(account_key),
         }
     }
 
@@ -31,42 +37,49 @@ impl Publisher {
     pub fn env(&self) -> &str {
         match self {
             Publisher::FilteringPublisher(p) => p.env(),
+            Publisher::LocalPublisher(p) => p.env(),
         }
     }
 
     pub fn wants_update_account(&self) -> bool {
         match self {
             Publisher::FilteringPublisher(p) => p.wants_update_account(),
+            Publisher::LocalPublisher(p) => p.wants_update_account(),
         }
     }
 
     pub fn wants_slot_status(&self) -> bool {
         match self {
             Publisher::FilteringPublisher(p) => p.wants_slot_status(),
+            Publisher::LocalPublisher(p) => p.wants_slot_status(),
         }
     }
 
     pub fn wants_transaction(&self) -> bool {
         match self {
             Publisher::FilteringPublisher(p) => p.wants_transaction(),
+            Publisher::LocalPublisher(p) => p.wants_transaction(),
         }
     }
 
     pub fn update_account(&self, ev: UpdateAccountEvent) -> Result<(), KafkaError> {
         match self {
             Publisher::FilteringPublisher(p) => p.update_account(ev),
+            Publisher::LocalPublisher(p) => p.update_account(ev),
         }
     }
 
     pub fn update_slot_status(&self, ev: SlotStatusEvent) -> Result<(), KafkaError> {
         match self {
             Publisher::FilteringPublisher(p) => p.update_slot_status(ev),
+            Publisher::LocalPublisher(p) => p.update_slot_status(ev),
         }
     }
 
     pub fn update_transaction(&self, ev: TransactionEvent) -> Result<(), KafkaError> {
         match self {
             Publisher::FilteringPublisher(p) => p.update_transaction(ev),
+            Publisher::LocalPublisher(p) => p.update_transaction(ev),
         }
     }
 }

--- a/src/publisher/mod.rs
+++ b/src/publisher/mod.rs
@@ -1,0 +1,72 @@
+mod filtering_publisher;
+pub mod kafka_publisher;
+pub use filtering_publisher::FilteringPublisher;
+use rdkafka::error::KafkaError;
+
+use crate::{allowlist::Allowlist, SlotStatusEvent, TransactionEvent, UpdateAccountEvent};
+
+pub enum Publisher {
+    FilteringPublisher(FilteringPublisher),
+}
+
+impl Publisher {
+    // -----------------
+    // Filter
+    // -----------------
+    pub fn get_allowlist(&self) -> Allowlist {
+        match self {
+            Publisher::FilteringPublisher(p) => p.get_allowlist(),
+        }
+    }
+
+    pub fn wants_account_key(&self, account_key: &[u8]) -> bool {
+        match self {
+            Publisher::FilteringPublisher(p) => p.wants_account_key(account_key),
+        }
+    }
+
+    // -----------------
+    // Publisher
+    // -----------------
+    pub fn env(&self) -> &str {
+        match self {
+            Publisher::FilteringPublisher(p) => p.env(),
+        }
+    }
+
+    pub fn wants_update_account(&self) -> bool {
+        match self {
+            Publisher::FilteringPublisher(p) => p.wants_update_account(),
+        }
+    }
+
+    pub fn wants_slot_status(&self) -> bool {
+        match self {
+            Publisher::FilteringPublisher(p) => p.wants_slot_status(),
+        }
+    }
+
+    pub fn wants_transaction(&self) -> bool {
+        match self {
+            Publisher::FilteringPublisher(p) => p.wants_transaction(),
+        }
+    }
+
+    pub fn update_account(&self, ev: UpdateAccountEvent) -> Result<(), KafkaError> {
+        match self {
+            Publisher::FilteringPublisher(p) => p.update_account(ev),
+        }
+    }
+
+    pub fn update_slot_status(&self, ev: SlotStatusEvent) -> Result<(), KafkaError> {
+        match self {
+            Publisher::FilteringPublisher(p) => p.update_slot_status(ev),
+        }
+    }
+
+    pub fn update_transaction(&self, ev: TransactionEvent) -> Result<(), KafkaError> {
+        match self {
+            Publisher::FilteringPublisher(p) => p.update_transaction(ev),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adding local environment support.

## Details

Outlined in the readme this adds support for a local environment. This is useful for testing
the plugin itself and/or understanding what events are emitted by running the plugin in a local
test validator.

This is accomplished by supporting two different local env config structures which result in
two different kind of publishers being initialized and added when the plugin loads.
Aside from that the plugin handlers are then unaware of the different publishers.

## Managing the Fork

Some modules were rearranged, but code that gets updated a lot and is common with the forked
repo stayed mostly in place. 
