### PR TITLE
fix: panic for invalid account_keys

### DIFF
--- a/src/events/replica_transaction_info.rs
+++ b/src/events/replica_transaction_info.rs
@@ -54,8 +54,9 @@ impl<'a> ReplicaTransactionInfo<'a> {
                 // of bounds are even matching up with the account keys at all
                 if key.is_none() {
                     debug!(
-                        "Prebalance idx {idx} is out of bounds for account_keys {}",
-                        account_keys.len()
+                        "Prebalance idx {idx} is out of bounds for account_keys {}. Signature: {}",
+                        account_keys.len(),
+                        self.signature().to_string()
                     );
                 }
                 key

--- a/src/events/replica_transaction_info.rs
+++ b/src/events/replica_transaction_info.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 
+use log::debug;
 use solana_geyser_plugin_interface::geyser_plugin_interface::ReplicaTransactionInfoV2;
 use solana_program::{message::SanitizedMessage, pubkey::Pubkey, slot_history::Slot};
 use solana_sdk::signature::Signature;
@@ -43,8 +44,23 @@ impl<'a> ReplicaTransactionInfo<'a> {
 
         let account_keys = self.account_keys();
         zero_balance_indexes
-            .iter()
-            .map(|&idx| account_keys[idx])
+            .into_iter()
+            .flat_map(|idx| {
+                let key = account_keys.get(idx);
+                // Even though this shouldn't happen, we see a balances array that doesn't match with
+                // the accout_keys array at times. We warn here and exclude this zero_balance
+                // account instead.
+                // However at that point there is not telling if the zero_balances which aren't out
+                // of bounds are even matching up with the account keys at all
+                if key.is_none() {
+                    debug!(
+                        "Prebalance idx {idx} is out of bounds for account_keys {}",
+                        account_keys.len()
+                    );
+                }
+                key
+            })
+            .cloned()
             .collect::<Vec<_>>()
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -568,7 +568,10 @@ impl KafkaPlugin {
     }
 
     fn log_ignore_account_update(info: &ReplicaAccountInfoV3, reason: &str) {
-        if log_enabled!(::log::Level::Debug) || log_enabled!(::log::Level::Trace) {
+        let debug_ignored_updates = std::env::var("GEYSER_DEBUG_IGNORED_UPDATES").is_ok();
+        if (debug_ignored_updates && log_enabled!(::log::Level::Debug))
+            || log_enabled!(::log::Level::Trace)
+        {
             match <&[u8; 32]>::try_from(info.owner) {
                 Ok(key) => {
                     let owner = Pubkey::new_from_array(*key);
@@ -592,7 +595,10 @@ impl KafkaPlugin {
         account_keys: &AccountKeys,
         reason: &str,
     ) {
-        if log_enabled!(::log::Level::Debug) || log_enabled!(::log::Level::Trace) {
+        let debug_ignored_updates = std::env::var("GEYSER_DEBUG_IGNORED_UPDATES").is_ok();
+        if (debug_ignored_updates && log_enabled!(::log::Level::Debug))
+            || log_enabled!(::log::Level::Trace)
+        {
             // The account keys don't only include programs, so it is impossible to tell
             // if a transaction is affecting system programs only.
             // We err on _tracing_ to avoid spamming the logs.


### PR DESCRIPTION
## Summary

Fixes panic when transactions post-balance array has more items than the account-keys.
Afaik this is technically incorrect but seems to be happening for mainnet.

## Details

We log the issue including the transaction signature and ignore the zero balance for which we
couldn't find a matching account key. We can use that signature to understand better what's
happening by investigating the transactions for which we run into the issue.
