### PR TITLE
fix: excessive threads to fetch allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ _Local Environment Config Values_ below.
         * If provided the request to the program_allowlist_url will add an
             'Authorization: <value>' header.
         * A sample auth header value would be 'Bearer my_long_secret_token'.
-* **program_allowlist_expiry_sec** (`u64`)
-    * Update iterval for allowlist from http url.
+* **program_allowlist_slot_interval** (u64)
+    * Slots interval which determines how many slots to wait before updating the allowlist.
 
 ### Global Config Values
 
@@ -147,7 +147,7 @@ are added to the `environments` array.
       "name": "dev",
       "program_allowlist_url": "https://example.com/supported-programs",
       "program_allowlist_auth": "Bearer <dev secret bearer token>",
-      "program_allowlist_expiry_sec": 30,
+      "program_allowlist_slot_interval": 150,
       "kafka": {
         "bootstrap.servers": "dev.bootstrap-server:9092",
         "sasl.username": "<username>",
@@ -164,7 +164,7 @@ are added to the `environments` array.
       "name": "stage",
       "program_allowlist_url": "https://example.com/supported-programs",
       "program_allowlist_auth": "Bearer <stage secret bearer token>",
-      "program_allowlist_expiry_sec": 15,
+      "program_allowlist_slot_interval": 90,
       "kafka": {
         "bootstrap.servers": "stage.bootstrap-server:9092",
         "sasl.username": "<username>",

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -332,7 +332,6 @@ mod tests {
             ..EnvConfigKafka::default()
         });
 
-
         let allowlist = Allowlist::new_from_config(&config).unwrap();
         assert_eq!(allowlist.len(), 3);
 
@@ -372,7 +371,7 @@ mod tests {
             .with_header("content-type", "text/plain")
             .with_body("{\"result\":[]}")
             .create();
-        
+
         let config = EnvConfig::Kafka(EnvConfigKafka {
             program_allowlist_url: [mockito::server_url(), "/allowlist.txt".to_string()].join(""),
             program_allowlist_slot_interval: 5,
@@ -421,7 +420,6 @@ mod tests {
                 .to_bytes()
         ));
 
-        
         // 4. Update if needed with slot causing update
         allowlist.update_from_http_if_needed_async(10);
         wait_for_update_completion(&allowlist);
@@ -470,5 +468,4 @@ mod tests {
                 .to_bytes()
         ));
     }
-
 }

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use serde::Deserialize;
 use simple_error::SimpleError;
 use solana_program::pubkey::Pubkey;
@@ -230,6 +231,8 @@ impl Allowlist {
             let url = self.http_url.clone();
             let auth_header = self.http_auth.clone();
             std::thread::spawn(move || {
+                let thread_id = std::thread::current().id();
+                debug!("Updating remote allowlist, thread {:?}", thread_id);
                 let program_allowlist = Self::fetch_remote_allowlist(&url, &auth_header);
                 if program_allowlist.is_err() {
                     return;
@@ -240,6 +243,7 @@ impl Allowlist {
 
                 let mut http_last_updated = http_last_updated.lock().unwrap();
                 *http_last_updated = std::time::Instant::now();
+                debug!("Updated remote allowlist, thread {:?}", thread_id);
             });
         }
     }

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -183,8 +183,13 @@ impl Allowlist {
     }
 
     fn is_updating(&self) -> bool {
-        let v = self.http_last_updated.try_lock();
-        v.is_err()
+        let v = self.http_updater_one.try_lock();
+        if v.is_err() {
+            true
+        } else {
+            let v = self.http_last_updated.try_lock();
+            v.is_err()
+        }
     }
 
     pub fn update_from_http(&mut self) -> PluginResult<()> {

--- a/src/env_config/config_kafka.rs
+++ b/src/env_config/config_kafka.rs
@@ -44,20 +44,20 @@ pub struct EnvConfigKafka {
     #[serde(default)]
     pub program_allowlist_auth: String,
 
-    /// Update iterval for allowlist from http url.
+    /// Slots interval which determines how many slots to wait before updating the allowlist.
     #[serde(default)]
-    pub program_allowlist_expiry_sec: u64,
+    pub program_allowlist_slot_interval: u64,
 }
 
 impl Default for EnvConfigKafka {
     fn default() -> Self {
         Self {
-            program_allowlist_expiry_sec: 60,
             name: Default::default(),
             kafka: Default::default(),
             program_allowlist: Default::default(),
             program_allowlist_url: Default::default(),
             program_allowlist_auth: Default::default(),
+            program_allowlist_slot_interval: 150, // roughly 60 secs
         }
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -198,11 +198,11 @@ impl GeyserPlugin for KafkaPlugin {
     ) -> PluginResult<()> {
         let publishers = &self.unwrap_publishers();
         if let PluginSlotStatus::Confirmed = status {
-                for publisher in publishers {
-                    publisher
-                        .get_allowlist()
-                        .update_from_http_if_needed_async(slot);
-                }
+            for publisher in publishers {
+                publisher
+                    .get_allowlist()
+                    .update_from_http_if_needed_async(slot);
+            }
         };
 
         let mut errors = Vec::new();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -149,19 +149,7 @@ impl GeyserPlugin for KafkaPlugin {
             return Ok(());
         }
 
-        // Trigger an update of the remote allowlist for each filter
-        // but don't wait for it to complete.
-        // NOTE: we trigger this even on account updates that we don't care about
-        // since checking if the update interval expired should be fairly cheap.
-        // If we see a large overhead we should reconsider
-        let now = std::time::Instant::now();
         let publishers = &self.unwrap_publishers();
-        for publisher in publishers {
-            publisher
-                .get_allowlist()
-                .update_from_http_if_needed_async(&now);
-        }
-
         if !publishers.iter().any(|p| p.wants_account_key(info.owner)) {
             Self::log_ignore_account_update(info, "No publisher wants this account");
             return Ok(());
@@ -209,6 +197,13 @@ impl GeyserPlugin for KafkaPlugin {
         status: PluginSlotStatus,
     ) -> PluginResult<()> {
         let publishers = &self.unwrap_publishers();
+        if let PluginSlotStatus::Confirmed = status {
+                for publisher in publishers {
+                    publisher
+                        .get_allowlist()
+                        .update_from_http_if_needed_async(slot);
+                }
+        };
 
         let mut errors = Vec::new();
         for publisher in publishers {


### PR DESCRIPTION
## Summary

Fixes excessive thread creation and resulting panic when we run out of them

Config Update:

Add
```json
{
  "program_allowlist_slot_interval": 150,
}
```
to each environment specific config to have it update about 1/min.

Example:

```json
{
  "environments": [
    {
      "name": "dev",
      "program_allowlist_url": "omitted",
      "program_allowlist_auth": "Bearer omitted",
      "program_allowlist_slot_interval": 150,
      "kafka": {
        "bootstrap.servers": "omit",
        "sasl.username": "omit",
        "more-props": "here"
      }
    }
  ]
}
```

## Details

Allowlist changes were made as follows:

- no more duration tracking, instead we use slots to _track time_ for us which is why we now
  take a slot interval instead
- thus the need for an update is checked once per slot (every 400ms) instead of once per
  account (much more frequent)
- the guard against multiple parallel requests did not work and was fixed by using a proper
  `bool` mutex which is toggled at start and end of update
- I tested this with `slot_interval` set to 5 and saw the updates performed one by one and
  thread count staying steady at 321 (local test validator)
- the thread id for those updates is logged as part of updates tracking on _debug_, however
  this id does _not_ represent the number of threads as I confirmed locally
- allowlist tests were reimplemented in a much simpler fashion
